### PR TITLE
Adds a rockspec to install using LuaRocks

### DIFF
--- a/lua-zip-git-1.rockspec
+++ b/lua-zip-git-1.rockspec
@@ -4,12 +4,9 @@ version = "git-1"
 description = {
     summary = "Lua binding to libzip",
     detailed = [[
-To use this library, you need libzip, get it here:
-     http://www.nih.at/libzip/
-
-To build this library, you need CMake, get it here:
-    http://www.cmake.org/cmake/resources/software.html
-    ]],
+lua-zip is a binding to libzip, which you can get from:
+    http://www.nih.at/libzip/
+]],
     homepage = "https://github.com/brimworks/lua-zip",
     license = "MIT"
 }


### PR DESCRIPTION
Sorry for the laggard response... apparently git-hub is now sending emails with a different "to" email address which means these emails got filtered out :(.  I've been out of touch with the Lua rocks community... but last I checked, an email needed to be sent to the list to announce lua-zip and get it into the lua rocks archive.  Do you mind sending that email?
