### PR TITLE
Declare ar:delete()

### DIFF
--- a/lua_zip.c
+++ b/lua_zip.c
@@ -716,6 +716,9 @@ static void S_register_archive(lua_State* L) {
     lua_pushcfunction(L, S_archive_rename);
     lua_setfield(L, -2, "rename");
 
+    lua_pushcfunction(L, S_archive_rename);
+    lua_setfield(L, -2, "delete");
+
     lua_pop(L, 1);
 }
 

--- a/test.lua
+++ b/test.lua
@@ -52,6 +52,7 @@ function main()
     test_add()
     test_replace()
     test_rename()
+    test_delete()
     test_zip_source()
     test_file_source()
 end
@@ -218,7 +219,6 @@ function test_delete()
     -- TODO: How do you determine if this is a directory?
     local sb = ar:stat(".ignore")
 
-    file:close()
     ar:close()
 end
 


### PR DESCRIPTION
You forgot to declare `ar:delete()` in `lua_zip.c`, I first ran the tests and realized it wasn't called there too, and now it passes your tests.