### PR TITLE
Fix. Compile with MSVC 2010.

### DIFF
--- a/lua-zip-git-1.rockspec
+++ b/lua-zip-git-1.rockspec
@@ -26,6 +26,7 @@ external_dependencies = {
       library = "zip",
    }
 }
+
 build = {
    type = "builtin",
    modules = {
@@ -35,6 +36,9 @@ build = {
          libdirs   = { "$(ZIP_LIBDIR)" },
          libraries = { "zip" },
       }
-   }
+   },
+   platforms = { windows = { modules = { ["brimworks.zip"] = {
+      libraries = { "zip", "advapi32", "kernel32", "user32" },
+      defines   = { "ZIP_STATIC" },
+   }}}},
 }
-

--- a/lua_zip.c
+++ b/lua_zip.c
@@ -75,10 +75,10 @@ static struct zip** check_archive(lua_State* L, int narg) {
  * just return 0.
  */
 static int S_push_error(lua_State* L, int zip_error, int sys_error) {
-    char buff[1024];
+    char buff[1024]; int len;
     if ( 0 == zip_error ) return 0;
 
-    int len = zip_error_to_str(buff, sizeof(buff), zip_error, sys_error);
+    len = zip_error_to_str(buff, sizeof(buff), zip_error, sys_error);
     if ( len >= sizeof(buff) ) len = sizeof(buff)-1;
     lua_pushlstring(L, buff, len);
 


### PR DESCRIPTION
About changes in rockspec.
In my tests it works for both static and dynamic versions of libzip.